### PR TITLE
Add cache handling

### DIFF
--- a/.env
+++ b/.env
@@ -1,5 +1,0 @@
-# Warning: Do not add secrets (API keys and similar) to this file, as it source controlled!
-# Use `.env.local` for any secrets, and ensure it is not added to source control
-
-NEXT_PUBLIC_SANITY_PROJECT_ID="dl8089iz"
-NEXT_PUBLIC_SANITY_DATASET="production"

--- a/.gitignore
+++ b/.gitignore
@@ -26,7 +26,6 @@ yarn-debug.log*
 yarn-error.log*
 
 # local env files
-.env*.local
 .env
 
 # vercel

--- a/.gitignore
+++ b/.gitignore
@@ -27,6 +27,7 @@ yarn-error.log*
 
 # local env files
 .env*.local
+.env
 
 # vercel
 .vercel

--- a/app/api/spins/route.ts
+++ b/app/api/spins/route.ts
@@ -6,7 +6,7 @@ type Show = { start: string; end: string; title: string; }
 async function getSpins(): Promise<Spin> {
   return fetch(`https://spinitron.com/api/spins`, {
     headers: {
-      'Authorization': `Bearer ${"VIT_hdbWICcgF3nGwvcLJCf6"}`
+      'Authorization': `Bearer ${process.env.SPINITRON_API_KEY}`
     },
     cache: 'no-store'
   }).then(async (res) => {
@@ -29,7 +29,7 @@ async function getSpins(): Promise<Spin> {
 async function getShows(): Promise<Show> {
   return fetch(`https://spinitron.com/api/shows`, {
     headers: {
-      'Authorization': `Bearer ${"VIT_hdbWICcgF3nGwvcLJCf6"}`
+      'Authorization': `Bearer ${process.env.SPINITRON_API_KEY}`
     },
     cache: 'no-store'
   }).then(async (res) => {

--- a/app/api/spins/route.ts
+++ b/app/api/spins/route.ts
@@ -76,7 +76,13 @@ export async function GET (
     // Try to get data from cache
     const cachedData = await redis.get(CACHE_KEY);
 
-    if (cachedData) { return NextResponse.json(cachedData); }
+    if (cachedData) {
+      return NextResponse.json(cachedData, {
+        headers: {
+          'Cache-Control': 'no-cache, no-store, must-revalidate'
+        }
+      });
+    }
 
     // If not in cache, fetch from APIs
     const [spins, shows] = await Promise.all([getSpins(), getShows()]);
@@ -100,6 +106,8 @@ export async function GET (
       start: "Error loading...",
       end: "Error loading...",
       title: "Error loading..."
-    }, { status: 500 });
+    }, { status: 500, headers: {
+      'Cache-Control': 'no-cache, no-store, must-revalidate'
+    } });
   }
 }

--- a/app/api/spins/route.ts
+++ b/app/api/spins/route.ts
@@ -1,7 +1,11 @@
 import { NextResponse } from "next/server";
+import { redis } from "../../../redis";
 
 type Spin = { music: string; artist: string; image: string; }
 type Show = { start: string; end: string; title: string; }
+
+const CACHE_KEY = 'spinitron:latestSpin';
+const CACHE_TTL = 10; // in seconds
 
 async function getSpins(): Promise<Spin> {
   return fetch(`https://spinitron.com/api/spins`, {
@@ -21,7 +25,7 @@ async function getSpins(): Promise<Spin> {
     return {
       music: "Loading...",
       artist: "Loading...",
-      image: "Loading..."
+      image: ""
     }
   });
 }
@@ -68,7 +72,34 @@ async function getShows(): Promise<Show> {
 export async function GET (
   request: Request
 ) {
-  const spins = await getSpins();
-  const shows = await getShows();
-  return NextResponse.json({ ...spins, ...shows });
+  try {
+    // Try to get data from cache
+    const cachedData = await redis.get(CACHE_KEY);
+
+    if (cachedData) { return NextResponse.json(cachedData); }
+
+    // If not in cache, fetch from APIs
+    const [spins, shows] = await Promise.all([getSpins(), getShows()]);
+    const combinedData = { ...spins, ...shows };
+
+    // Store data in cache
+    try {
+      await redis.set(CACHE_KEY, JSON.stringify(combinedData), {ex: CACHE_TTL});
+    } catch (cacheError) {
+      console.error("Error setting cache:", cacheError);
+    }
+
+    return NextResponse.json(combinedData);
+
+  } catch (error) {
+    console.error("Error in GET handler:", error);
+    return NextResponse.json({
+      music: "Error loading...",
+      artist: "Error loading...",
+      image: "",
+      start: "Error loading...",
+      end: "Error loading...",
+      title: "Error loading..."
+    }, { status: 500 });
+  }
 }

--- a/app/api/spins/route.ts
+++ b/app/api/spins/route.ts
@@ -100,7 +100,7 @@ export async function GET (
       headers: {
         'Content-Type': 'application/json',
         'Cache-Control': 'no-cache, no-store, must-revalidate'
-    });
+    }});
   } catch (error) {
     console.error("Error in GET handler:", error);
     return NextResponse.json({

--- a/app/api/spins/route.ts
+++ b/app/api/spins/route.ts
@@ -7,6 +7,8 @@ type Show = { start: string; end: string; title: string; }
 const CACHE_KEY = 'spinitron:latestSpin';
 const CACHE_TTL = 10; // in seconds
 
+export const dynamic = 'force-dynamic'; // disable static caching
+
 async function getSpins(): Promise<Spin> {
   return fetch(`https://spinitron.com/api/spins`, {
     headers: {

--- a/app/api/spins/route.ts
+++ b/app/api/spins/route.ts
@@ -79,6 +79,7 @@ export async function GET (
     if (cachedData) {
       return NextResponse.json(cachedData, {
         headers: {
+          'Content-Type': 'application/json',
           'Cache-Control': 'no-cache, no-store, must-revalidate'
         }
       });
@@ -95,8 +96,11 @@ export async function GET (
       console.error("Error setting cache:", cacheError);
     }
 
-    return NextResponse.json(combinedData);
-
+    return NextResponse.json(combinedData, {
+      headers: {
+        'Content-Type': 'application/json',
+        'Cache-Control': 'no-cache, no-store, must-revalidate'
+    });
   } catch (error) {
     console.error("Error in GET handler:", error);
     return NextResponse.json({
@@ -107,6 +111,7 @@ export async function GET (
       end: "Error loading...",
       title: "Error loading..."
     }, { status: 500, headers: {
+      'Content-Type': 'application/json',
       'Cache-Control': 'no-cache, no-store, must-revalidate'
     } });
   }

--- a/app/ui/PlayButton.tsx
+++ b/app/ui/PlayButton.tsx
@@ -2,7 +2,7 @@
 import Image from "next/image"
 import { useRef, useState } from "react";
 
-const STREAM_SRC = "http://166.62.119.4:8000/stream";
+const STREAM_SRC = "https://166.62.119.4:8000/stream";
 
 export default function PlayButton() {
     const audioRef = useRef<HTMLAudioElement>(null);

--- a/app/ui/PlayButton.tsx
+++ b/app/ui/PlayButton.tsx
@@ -2,8 +2,6 @@
 import Image from "next/image"
 import { useRef, useState } from "react";
 
-const STREAM_SRC = "https://166.62.119.4:8000/stream";
-
 export default function PlayButton() {
     const audioRef = useRef<HTMLAudioElement>(null);
     const [isPlaying, setIsPlaying] = useState(false);
@@ -33,7 +31,7 @@ export default function PlayButton() {
                 )}
             </button>
             {/* rainy dawg was down */}
-            <audio ref={audioRef} src={STREAM_SRC} preload="none"></audio>
+            <audio ref={audioRef} src="/api/audio" preload="none"></audio>
         </>
     )
 }

--- a/app/ui/PlayerTest.tsx
+++ b/app/ui/PlayerTest.tsx
@@ -2,7 +2,7 @@
 import { useEffect, useState } from "react";
 import PlayButton from "./PlayButton";
 import Image from "next/image";
-const REQUEST_RATE = 1000 * 10; // 10 seconds
+const REQUEST_RATE = 1000 * 3; // 3 seconds
 
 function Player() {
   const [spins, setSpins] = useState<any>(null);

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -1,27 +1,30 @@
 /** @type {import('next').NextConfig} */
 const nextConfig = {
     images: {
-        remotePatterns: [
-            {
-                hostname: '**.mzstatic.com'
-            }
-        ],
-        domains: ['cdn.sanity.io', 'spinitron.com'],
+      remotePatterns: [
+        {
+          hostname: '**.mzstatic.com'
+        }
+      ],
+      domains: ['cdn.sanity.io', 'spinitron.com'],
     },
     async redirects() {
-        return [
-          {
-            source: '/admin/:path*',
-            destination: 'https://rainydawg.sanity.studio',
-            permanent: true,
-          },
-          {
-            source: "/api/audio",
-            destination: "http://166.62.119.4:8000/stream",
-            permanent: true,
-          }
-        ]
-      },
+      return [
+        {
+          source: '/admin/:path*',
+          destination: 'https://rainydawg.sanity.studio',
+          permanent: true,
+        },
+      ]
+    },
+    async rewrites() {
+      return [
+        {
+          source: "/api/audio",
+          destination: "http://166.62.119.4:8000/stream",
+        },
+      ];
+    },
 };
 
 export default nextConfig;

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -15,6 +15,11 @@ const nextConfig = {
             destination: 'https://rainydawg.sanity.studio',
             permanent: true,
           },
+          {
+            source: "/api/audio",
+            destination: "http://166.62.119.4:8000/stream",
+            permanent: true,
+          }
         ]
       },
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "@portabletext/react": "^3.0.13",
         "@sanity/image-url": "^1.0.2",
         "@sanity/vision": "^3.28.0",
+        "@upstash/redis": "^1.34.9",
         "next": "14.1.0",
         "next-sanity": "^7.1.1",
         "next-sanity-image": "^6.1.1",
@@ -2608,6 +2609,14 @@
       "integrity": "sha512-zuVdFrMJiuCDQUMCzQaD6KL28MjnqqN8XnAqiEq9PNm/hCPTSGfrXCOfwj1ow4LFb/tNymJPwsNbVePc1xFqrQ==",
       "dev": true
     },
+    "node_modules/@upstash/redis": {
+      "version": "1.34.9",
+      "resolved": "https://registry.npmjs.org/@upstash/redis/-/redis-1.34.9.tgz",
+      "integrity": "sha512-7qzzF2FQP5VxR2YUNjemWs+hl/8VzJJ6fOkT7O7kt9Ct8olEVzb1g6/ik6B8Pb8W7ZmYv81SdlVV9F6O8bh/gw==",
+      "dependencies": {
+        "crypto-js": "^4.2.0"
+      }
+    },
     "node_modules/@vercel/stega": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/@vercel/stega/-/stega-0.1.0.tgz",
@@ -3666,6 +3675,11 @@
       "engines": {
         "node": ">= 8"
       }
+    },
+    "node_modules/crypto-js": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/crypto-js/-/crypto-js-4.2.0.tgz",
+      "integrity": "sha512-KALDyEYgpY+Rlob/iriUtjV6d5Eq+Y191A5g4UqLAi8CyGP9N1+FdVbkc1SxKc2r4YAYqG8JzO2KGL+AizD70Q=="
     },
     "node_modules/crypto-random-string": {
       "version": "2.0.0",

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "@portabletext/react": "^3.0.13",
     "@sanity/image-url": "^1.0.2",
     "@sanity/vision": "^3.28.0",
+    "@upstash/redis": "^1.34.9",
     "next": "14.1.0",
     "next-sanity": "^7.1.1",
     "next-sanity-image": "^6.1.1",

--- a/redis.ts
+++ b/redis.ts
@@ -1,0 +1,6 @@
+import { Redis } from "@upstash/redis";
+
+export const redis = new Redis({
+  url: process.env.UPSTASH_REDIS_REST_URL!,
+  token: process.env.UPSTASH_REDIS_REST_TOKEN!,
+});

--- a/sanity.config.js
+++ b/sanity.config.js
@@ -13,7 +13,7 @@ import {schema} from './sanity/schema'
 export default defineConfig({
   basePath: '/studio',
   projectId: '4sifji3s',
-  dataset: 'Rainy Dawg Radio 2024',
+  dataset: 'production',
   // Add and edit the content schema in the './sanity/schema' folder
   schema,
   plugins: [

--- a/sanity.config.js
+++ b/sanity.config.js
@@ -12,8 +12,8 @@ import {schema} from './sanity/schema'
 
 export default defineConfig({
   basePath: '/studio',
-  projectId: '4sifji3s',
-  dataset: 'production',
+  projectId,
+  dataset,
   // Add and edit the content schema in the './sanity/schema' folder
   schema,
   plugins: [


### PR DESCRIPTION
## Add cache handling

Fixes cache issues preventing the spins and shows from updating. This also prevents the `304` HTTP status responses by forcing the cache to revalidate. 

### Integrate KV cache

* Adds a redis database to store the cached data values, following the Spinitron API guidelines
* Cache data with TTL of 10 seconds to prevent excessive API calls
* Explicitly define `'Cache-Control': 'no-cache, no-store, must-revalidate'` for the `NextResponse` values to ensure that data is forcibly refreshed as needed

### Other changes

* Refactor environmental variables to use `process.env`
* Redirect the http stream using Next.js `rewrites`